### PR TITLE
Specify encoding (and throw in fancy accents)

### DIFF
--- a/education/index.html
+++ b/education/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK education</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -50,7 +51,7 @@
                     September 2015.</p>
 
                     <p>As last year, it will be held at the Coventry University Technology
-                    Centre and include the usual smorgasbord of talks, tutorials,
+                    Centre and include the usual smörgåsbord of talks, tutorials,
                     workshops and keynotes. As in previous years there will be the hugely
                     popular social events too: a conference meal, a charity social event
                     on Friday evening (in aid of Cancer Research UK) and the famous

--- a/register/index.html
+++ b/register/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK registration</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/science/index.html
+++ b/science/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK Science track</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/talks/index.html
+++ b/talks/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK talks</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/venue/index.html
+++ b/venue/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK venue</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK volunteering</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/wiki/accomodation.html
+++ b/wiki/accomodation.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK WIKI</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/wiki/code.html
+++ b/wiki/code.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK WIKI</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/wiki/faq.html
+++ b/wiki/faq.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK WIKI</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>Pycon UK WIKI</title>
+    <meta charset="utf-8">
     <meta name="description" content="Pycon UK website">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/wiki/sprints.html
+++ b/wiki/sprints.html
@@ -3,6 +3,7 @@
 <head>
     <title>Pycon UK WIKI</title>
     <meta name="description" content="Pycon UK website">
+    <meta charset="utf-8">
     <meta name="author" content="Blanc =vs= Pycon UK">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../static/css/style.css">


### PR DESCRIPTION
While adding a playful update to "internationalise" the spelling of smorgasbord, I realised that I didn't know what encoding the pages were. Just to show willing, this PR adds an explicit UTF-8 charset header to each and includes the smorgasbord update.

AFAICT, none of the other pages needed re-encoding as such; I've merely added the explicit header.
