### PR TITLE
Contributions guidance!

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,20 @@
+Contributing to the PyconUK Website
+-----------------------------------
+
+Hey! Many thanks for wanting to improve the PyconUK website!
+
+Contributions are welcome without prejudice from *anyone* irrespective of
+age, gender, religion, race or sexuality. Good quality code and engagement
+with respect, humour and intelligence wins every time.
+
+Feedback may be given for contributions and, where necessary, changes will
+be politely requested and discussed with the originating author. Respectful
+yet robust argument is most welcome.
+
+By contributing code to the project you agree that:
+
+* You have the authority to place your code under our licensing terms (see LICENSE.rst);
+* You don't mind your contribution being made public.
+* There is no guarantee that your contribution will be accepted into the source code.
+
+Yay! :-)

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ PyconUK website
 
 This is the website for PyconUK. It is hosted via GitHub Pages and available via http://pyconuk.org/.
 
-We welcome pull requests for improvements!
+We welcome pull requests for improvements! (Please see CONTRIBUTING.rst for details.)
 
 Use the following process to submit changes:
 


### PR DESCRIPTION
This branch adds a `CONTRIBUTING.rst` file that GitHub will automatically display when third parties make a pull request. It includes standard sensible guidance and expectations for those contributing. It's also deliberately friendly.

It's a start and I expect the wording will change (it's based on the one I use in the drogulus, itself sourced from some place I can't remember where).
