### PR TITLE
Have Jekyll ignore the `vendor` dir (yay bundler)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,5 @@ url: "http://yourdomain.com" # the base hostname & protocol for your site
 
 # Build settings
 markdown: kramdown
+exclude:
+    - vendor


### PR DESCRIPTION
See https://github.com/jekyll/jekyll/issues/2938 and
https://travis-ci.org/PyconUK/pyconuk.github.io/builds/55404654
