### PR TITLE
Add code of conduct to static site...

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ email: your-email@domain.com
 description: > # this means to ignore newlines until "baseurl:"
   PyCon UK website
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://yourdomain.com" # the base hostname & protocol for your site
+url: "http://pyconuk.org" # the base hostname & protocol for your site
 
 # Build settings
 markdown: kramdown

--- a/codeofconduct/index.html
+++ b/codeofconduct/index.html
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Talks
+body_class_hack: talks
+---
+
+<div class="intro">
+	<div class="column_intro">
+		<div class="textblock">
+			<h1 class="huge">Code of Conduct</h1>
+		</div>
+	</div>
+</div>
+
+<article class="main-article">
+	<div class="content">
+		<div class="column_content">
+			<div class="textblock">
+            <h2>PyCon UK's Statement on Diversity and Conduct</h2>
+
+            <p>Happily, PyconUK is a diverse community who maintain a
+            reputation as a friendly, welcoming and dynamic group.</p>
+
+            <p>We trust that attendees will treat each other in a way that
+            reflects the widely held view that diversity and friendliness are
+            strengths of our community to be celebrated and fostered.</p>
+
+            <p>Furthermore, we believe attendees have a right to:</p>
+
+            <ul>
+                <li>be treated with courtesy, dignity and respect;</li>
+                <li>be free from any form of discrimination, victimisation,
+                harassment or bullying;</li>
+                <li>enjoy an environment free from unwelcome behaviour,
+                inappropriate language and unsuitable imagery.</li>
+            </ul>
+
+            <p>If problems covered by this code of conduct arise, please
+            contact a PyconUK organiser directly and in private. Any complaint
+            will remain confidential, be taken seriously, investigated, and
+            dealt with appropriately.</p>
+
+            <p>PyconUK reserves the right to carry out any of the following
+            actions relating to a complaint:</p>
+
+            <ul>
+                <li>The person concerned may be told to stop/modify their
+                behaviour appropriately and a warning will be issued. </li>
+                <li>The person concerned may be warned that enforcement action
+                may be taken if the behaviour continues.</li>
+                <li>The person concerned may be asked to leave the venue
+                immediately and/or will be prohibited from continuing to
+                attend PyconUK (without reimbursement).</li>
+                <li>The incident may be reported to the Police.</li>
+            </ul>
+
+            <p>(This document is released under a
+            <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">creative commons license</a>.)</p>
+			</div>
+		</div>
+	</div>
+</article>

--- a/codeofconduct/index.html
+++ b/codeofconduct/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Talks
-body_class_hack: talks
+title: Code Of Conduct
+body_class_hack: codeofconduct
 ---
 
 <div class="intro">

--- a/codeofconduct/index.html
+++ b/codeofconduct/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Code Of Conduct
-body_class_hack: codeofconduct
+body_class_hack: talks
 ---
 
 <div class="intro">


### PR DESCRIPTION
This branch introduces two changes:
1. I've added copy of the code of conduct so I have somewhere that's not a wiki I can link to from the ticket booking form (attendees should tick a check box to say they have read, understood and agree to abide by the CoC as part of the ticket booking process).
2. I've updated the _config.yml file so the URL is for our pyconuk.org website.
