### PR TITLE
Strip `pyconuk.org` from URLs when checking output HTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 script:
     - bundle exec jekyll build
-    - bundle exec htmlproof _site/
+    - bundle exec htmlproof --href-swap ".*pyconuk.org/:/" _site/


### PR DESCRIPTION
Canonical links should include the domain part, but `html-proofer` just
treats them as normal external links (see
https://github.com/gjtorikian/html-proofer/issues/170) so will fail on
PRs adding new pages.

Ideally `html-proofer` would just strip the domain part from canonical
links, but until then, this just strips the `pyconuk.org` domain part
from _all_ `href`s - not quite ideal, but avoids me writing Ruby.
