### PR TITLE
Add baby steps for getting dev env up and running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+help:
+	@echo 'Makefile for pyconuk.org'
+	@echo ''
+	@echo 'Usage:'
+	@echo '   make build                       build the docker container'
+	@echo '   make run                         run the docker container'
+	@echo ''
+
+build:
+	docker build -t pyconuk.org .
+
+run:
+	docker run -p 80:4000 -v $(pwd):/opt/pyconuk/site:rw -ti pyconuk.org

--- a/README.rst
+++ b/README.rst
@@ -25,19 +25,27 @@ That's it!
 Usage
 -----
 
-This site uses Jekyll_. The official docs are good, but here's a quickstart:
+Installation
+~~~~~~~~~~~~
+This site uses Jekyll_ and we've wrapped the development environment in Docker.
 
-* Ensure you have rvm_ or rbenv_
-* Ensure you have bundler_ - if you can't ``bundle`` on the command line, ``gem install bundler``
-* ``bundle install`` in the git repo to fetch the dependencies
-* ``bundle exec jekyll serve -w`` will run a development server listening on port 4000
-* ``bundle exec jekyll build`` will build the site in ``$gitroot/_site/``
+0. (OS X only) Install boot2docker_ (you can also homebrew it)
+1. Install docker_
+2. Build the docker image (this may take some time): ``docker build -t pyconukorg .``
+3. Run the docker image: ``docker run -p 80:4000 -ti pyconukorg``
+4. Get your docker ip: ``docker ip`` (or ``boot2docker ip`` if you're using that)
+5. Open your web browser of choice and go to the IP from step 4
 
+
+Development
+~~~~~~~~~~~
 Pages are essentially `Liquid templates`_. Essentially stick some YAML front-matter at the start containing page metadata (like `layout` and `title`) at the top of a Markdown / HTML file of content.
 
 Travis will test branches, and branches won't get merged without review and passing tests, so dive right in!
 
 .. _Jekyll: http://jekyllrb.com/
+.. _boot2docker: http://docs.docker.com/installation/mac/
+.. _docker: https://docs.docker.com/installation/#installation
 .. _rvm: https://rvm.io/
 .. _rbenv: http://rbenv.org/
 .. _bundler: http://bundler.io/

--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,9 @@ This site uses Jekyll_ and we've wrapped the development environment in Docker.
 
 0. (OS X only) Install boot2docker_ (you can also homebrew it)
 1. Install docker_
-2. Build the docker image (this may take some time): ``docker build -t pyconukorg .``
-3. Run the docker image: ``docker run -p 80:4000 -ti pyconukorg``
-4. Get your docker ip: ``docker ip`` (or ``boot2docker ip`` if you're using that)
+2. Build the docker image (this may take some time): ``make build``
+3. Run the docker image: ``make run``
+4. Get your [docker] ip. On OS X do: ``boot2docker ip``, one Linux this is your external IP
 5. Open your web browser of choice and go to the IP from step 4
 
 


### PR DESCRIPTION
This fixes #23 (and assumes @ntoll doesn't know what he's doing ;)

Replace Jekyll environment set up steps with Docker instructions.

Please **_don't_** merge this before #25!
