### PR TITLE
Remove pointless Wiki link and replace with Code of Conduct

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
 				<li><a {% if page.title == "Education" %} class="active"{% endif %}href="/education/">Education</a></li>
 				<li class="halfway"><a {% if page.title == "Science" %} class="active"{% endif %}href="/science/">Science</a></li>
 				<li><a{% if page.title == "Volunteering" %} class="active"{% endif %} href="/volunteer/">Volunteer</a></li>
-				<li><a{% if page.title == "Wiki" %} class="active"{% endif %} href="/wiki/">Wiki</a></li>
+				<li><a{% if page.title == "Code Of Conduct" %} class="active"{% endif %} href="/codeofconduct/">CoC</a></li>
 				<li><a{% if page.title == "Registration" %} class="active"{% endif %} class="now" href="/register/">Register</a></li>
 			</ul>
 		</nav>


### PR DESCRIPTION
This branch introduces two changes:
- The menu item entitled "Wiki" that links to an empty page called "Wiki" is removed (it wasn't doing anything and just wasting space).
- A new menu item "CoC" replace the "Wiki" item and links to the Code of Conduct page instead.
