### PR TITLE
Clarification of recruitment cost for non-sponsors

### DIFF
--- a/sponsorship/index.html
+++ b/sponsorship/index.html
@@ -61,7 +61,7 @@ body_class_hack: education
 
             <p>All sponsors are eligible to take part, for free, in the
             PyCon UK recruitment event. Non-sponsors will need to pay a
-            fee.</p>
+            fee of &pound;500 (in advance) to take part.</p>
 
             <h2>Next Steps</h2>
 


### PR DESCRIPTION
This branch adds a note of the amount of money non-sponsors need to pay to take part in the recruitment event. The idea is to actually make them prefer to sponsor us. ;-)
