### PR TITLE
Make google form confine to text size and be reponsive to screen size

### DIFF
--- a/programme/index.html
+++ b/programme/index.html
@@ -44,7 +44,7 @@ body_class_hack: talks
                 <p>So, if you'd like to submit a proposal for a talk or a workshop, please fill
                 out the form below.</p>
 
-                <iframe src="https://docs.google.com/forms/d/1J09LIQu9genC1rZdaBxpiP_AhntaIdYqg9v_0kKAWac/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+                <iframe src="https://docs.google.com/forms/d/1J09LIQu9genC1rZdaBxpiP_AhntaIdYqg9v_0kKAWac/viewform?embedded=true" width="100%" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
 
             </div>
         </div>


### PR DESCRIPTION
Google form does not work well on mobile screens. This fixes that. Will also make the form have the same width as the text on the page
